### PR TITLE
Set absolute path for OG image

### DIFF
--- a/pages/games/[gameId]/result.tsx
+++ b/pages/games/[gameId]/result.tsx
@@ -98,7 +98,7 @@ export default function Result({ game }: { game: GameData | null }) {
 
   return (
     <Layout
-      ogImageUrl={`/api/og?gameId=${game.id}`}
+      ogImageUrl={`${process.env.SERVERHOST}/api/og?gameId=${game.id}`}
       title={`${game.username}'s GitHub-Guessr score is ${score}!`}
     >
       <main className={"flex flex-col items-center justify-center flex-1 px-2"}>


### PR DESCRIPTION
## WHY
The OG image is not being displayed on SNS.

## WHAT
The reason is that the OG image URL is set as a relative path. We need to change it to an absolute path.